### PR TITLE
Fix Comparator __eq__ method to include type in comparison, and treat And/Or as immutable

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,10 @@
 0.4 (unreleased)
 ----------------
 
+- Don't modify queries attribute when optimizing And or Or, return a new
+  instance instead. This change is needed to open new optimization
+  possibilities, like factorization.
+
 - Fix Comparator __eq__ method to include type in comparison,
   previously NotAny('index', [1]) was equal to Any('index', [1]) for example.
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,10 @@
+0.4 (unreleased)
+----------------
+
+- Fix Comparator __eq__ method to include type in comparison,
+  previously NotAny('index', [1]) was equal to Any('index', [1]) for example.
+
+
 0.3 (2014-06-12)
 ----------------
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -109,3 +109,5 @@ Contributors
 - Chris McDonough, 2012/06/13
 
 - Balazs Ree 2013/09/08
+
+- Vincent Fretin, 2016/04/03

--- a/hypatia/query/__init__.py
+++ b/hypatia/query/__init__.py
@@ -93,7 +93,8 @@ class Comparator(Query):
         return ' '.join((self.index.qname(), self.operator, repr(self._value)))
 
     def __eq__(self, other):
-        return self.index == other.index and self._value == other._value
+        return (type(self) == type(other) and
+                self.index == other.index and self._value == other._value)
 
     def flush(self, *arg, **kw):
         self.index.flush(*arg, **kw)

--- a/hypatia/query/__init__.py
+++ b/hypatia/query/__init__.py
@@ -416,6 +416,9 @@ class BoolOp(Query):
     def __str__(self):
         return type(self).__name__
 
+    def __eq__(self, other):
+        return type(self) == type(other) and self.queries == other.queries
+
     def flush(self, *arg, **kw):
         for query in self.queries:
             query.flush(*arg, **kw)
@@ -434,7 +437,7 @@ class BoolOp(Query):
             if index is not None:
                 break
             queries.extend(list(subq.iter_children()))
-        
+
         if index is None:
             raise ValueError('No query has a reference to an index')
 
@@ -452,16 +455,6 @@ class BoolOp(Query):
     def iter_children(self):
         for query in self.queries:
             yield query
-
-    def _optimize(self):
-        self.queries = [query._optimize() for query in self.queries]
-        new_me = self._optimize_eq()
-        if new_me is not None:
-            return new_me
-        new_me = self._optimize_not_eq()
-        if new_me is not None:
-            return new_me
-        return self
 
     def _optimize_eq(self):
         # If all queries are Eq operators for the same index, we can replace
@@ -519,15 +512,19 @@ class Or(BoolOp):
         return And(*neg_queries)
 
     def _optimize(self):
-        new_self = BoolOp._optimize(self)
-        if self is not new_self:
-            return new_self
+        new_me = self._optimize_eq()
+        if new_me is not None:
+            return new_me
 
+        new_me = self._optimize_not_eq()
+        if new_me is not None:
+            return new_me
+
+        queries = [query._optimize() for query in self.queries]
         # There might be a combination of Gt/Ge and Lt/Le operators for the
         # same index that could be used to compose a NotInRange.
         uppers = {}
         lowers = {}
-        queries = list(self.queries)
 
         def process_range(i_lower, query_lower, i_upper, query_upper):
             queries[i_lower] = NotInRange.fromGTLT(
@@ -556,8 +553,7 @@ class Or(BoolOp):
         if len(queries) == 1:
             return queries[0]
 
-        self.queries = queries
-        return self
+        return self.__class__(*queries)
 
 
 class And(BoolOp):
@@ -578,15 +574,19 @@ class And(BoolOp):
         return Or(*neg_queries)
 
     def _optimize(self):
-        new_self = BoolOp._optimize(self)
-        if self is not new_self:
-            return new_self
+        new_me = self._optimize_eq()
+        if new_me is not None:
+            return new_me
 
+        new_me = self._optimize_not_eq()
+        if new_me is not None:
+            return new_me
+
+        queries = [query._optimize() for query in self.queries]
         # There might be a combination of Gt/Ge and Lt/Le operators for the
         # same index that could be used to compose an InRange.
         uppers = {}
         lowers = {}
-        queries = list(self.queries)
 
         def process_range(i_lower, query_lower, i_upper, query_upper):
             queries[i_lower] = InRange.fromGTLT(query_lower, query_upper)
@@ -614,8 +614,7 @@ class And(BoolOp):
         if len(queries) == 1:
             return queries[0]
 
-        self.queries = queries
-        return self
+        return self.__class__(*queries)
 
 
 class Not(Query):

--- a/hypatia/query/tests.py
+++ b/hypatia/query/tests.py
@@ -155,6 +155,11 @@ class TestContains(ComparatorTestBase):
         inst = self._makeOne('index', 'val')
         self.assertEqual(inst.negate(), NotContains('index', 'val'))
 
+    def test_not_equal_to_another_type(self):
+        from . import NotContains
+        inst = self._makeOne('index', 'val')
+        self.assertNotEqual(inst, NotContains('index', 'val'))
+
 
 class TestNotContains(ComparatorTestBase):
 
@@ -202,6 +207,11 @@ class TestEq(ComparatorTestBase):
         inst = self._makeOne('index', 'val')
         self.assertEqual(inst.negate(), NotEq('index', 'val'))
 
+    def test_not_equal_to_another_type(self):
+        from . import NotEq
+        inst = self._makeOne('index', 'val')
+        self.assertNotEqual(inst, NotEq('index', 'val'))
+
 
 class TestNotEq(ComparatorTestBase):
 
@@ -225,6 +235,11 @@ class TestNotEq(ComparatorTestBase):
         from . import Eq
         inst = self._makeOne('index', 'val')
         self.assertEqual(inst.negate(), Eq('index', 'val'))
+
+    def test_not_equal_to_another_type(self):
+        from . import Eq
+        inst = self._makeOne('index', 'val')
+        self.assertNotEqual(inst, Eq('index', 'val'))
 
 
 class TestGt(ComparatorTestBase):
@@ -250,6 +265,11 @@ class TestGt(ComparatorTestBase):
         inst = self._makeOne('index', 'val')
         self.assertEqual(inst.negate(), Le('index', 'val'))
 
+    def test_not_equal_to_another_type(self):
+        from . import Ge
+        inst = self._makeOne('index', 'val')
+        self.assertNotEqual(inst, Ge('index', 'val'))
+
 
 class TestLt(ComparatorTestBase):
 
@@ -273,6 +293,11 @@ class TestLt(ComparatorTestBase):
         from . import Ge
         inst = self._makeOne('index', 'val')
         self.assertEqual(inst.negate(), Ge('index', 'val'))
+
+    def test_not_equal_to_another_type(self):
+        from . import Ge
+        inst = self._makeOne('index', 'val')
+        self.assertNotEqual(inst, Ge('index', 'val'))
 
 
 class TestGe(ComparatorTestBase):
@@ -298,6 +323,11 @@ class TestGe(ComparatorTestBase):
         inst = self._makeOne('index', 'val')
         self.assertEqual(inst.negate(), Lt('index', 'val'))
 
+    def test_not_equal_to_another_type(self):
+        from . import Lt
+        inst = self._makeOne('index', 'val')
+        self.assertNotEqual(inst, Lt('index', 'val'))
+
 
 class TestLe(ComparatorTestBase):
 
@@ -322,6 +352,11 @@ class TestLe(ComparatorTestBase):
         inst = self._makeOne('index', 'val')
         self.assertEqual(inst.negate(), Gt('index', 'val'))
 
+    def test_not_equal_to_another_type(self):
+        from . import Lt
+        inst = self._makeOne('index', 'val')
+        self.assertNotEqual(inst, Lt('index', 'val'))
+
 
 class TestAll(ComparatorTestBase):
 
@@ -345,6 +380,11 @@ class TestAll(ComparatorTestBase):
         inst = self._makeOne('index', 'val')
         self.assertEqual(inst.negate(), NotAll('index', 'val'))
 
+    def test_not_equal_to_another_type(self):
+        from . import Any
+        inst = self._makeOne('index', 'val')
+        self.assertNotEqual(inst, Any('index', 'val'))
+
 
 class TestNotAll(ComparatorTestBase):
 
@@ -367,6 +407,11 @@ class TestNotAll(ComparatorTestBase):
         from . import All
         inst = self._makeOne('index', 'val')
         self.assertEqual(inst.negate(), All('index', 'val'))
+
+    def test_not_equal_to_another_type(self):
+        from . import Any
+        inst = self._makeOne('index', 'val')
+        self.assertNotEqual(inst, Any('index', 'val'))
 
 
 class TestAny(ComparatorTestBase):
@@ -421,6 +466,11 @@ class TestAny(ComparatorTestBase):
         inst = self._makeOne('index', 'val')
         self.assertEqual(inst.negate(), NotAny('index', 'val'))
 
+    def test_not_equal_to_another_type(self):
+        from . import NotAny
+        inst = self._makeOne('index', 'val')
+        self.assertNotEqual(inst, NotAny('index', 'val'))
+
 
 class TestNotAny(ComparatorTestBase):
 
@@ -443,6 +493,11 @@ class TestNotAny(ComparatorTestBase):
         from . import Any
         inst = self._makeOne('index', 'val')
         self.assertEqual(inst.negate(), Any('index', 'val'))
+
+    def test_not_equal_to_another_type(self):
+        from . import Any
+        inst = self._makeOne('index', 'val')
+        self.assertNotEqual(inst, Any('index', 'val'))
 
 
 class TestInRange(ComparatorTestBase):


### PR DESCRIPTION
- Fix Comparator `__eq__` method to include type in comparison, previously NotAny('index', [1]) was equal to Any('index', [1]) for example.
- Don't modify queries attribute when optimizing And or Or, return a new instance instead. This change is needed to open new optimization possibilities, like factorization.