### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Hypatia
         :target: https://travis-ci.org/Pylons/hypatia
 
 .. image:: https://readthedocs.org/projects/hypatia/badge/?version=latest
-        :target: http://hypatia.readthedocs.org/en/latest/
+        :target: https://hypatia.readthedocs.io/en/latest/
         :alt: Documentation Status
 
 A Python indexing and searching system.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
