### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,7 +9,7 @@ You will need `Python <http://python.org>`_ version 2.6 or better to run
 primarily under Python 2.7, so that version is recommended.  It does *not*
 run under Python 3.X.
 
-.. warning:: To succesfully install :mod:`hypatia`, you will need an
+.. warning:: To successfully install :mod:`hypatia`, you will need an
    environment capable of compiling Python C code.  See the
    documentation about installing, e.g. ``gcc`` and ``python-devel``
    for your system.  You will also need :term:`setuptools` installed

--- a/hypatia/text/baseindex.py
+++ b/hypatia/text/baseindex.py
@@ -241,7 +241,7 @@ class BaseIndex(Persistent):
     # Subclass must override.
     # It's not clear what it should do.  It must return an upper bound on
     # document scores for the query.  It would be nice if a document score
-    # divided by the query's query_weight gave the proabability that a
+    # divided by the query's query_weight gave the probability that a
     # document was relevant, but nobody knows how to do that.  For
     # CosineIndex, the ratio is the cosine of the angle between the document
     # and query vectors.  For OkapiIndex, the ratio is a (probably


### PR DESCRIPTION
There are small typos in:
- docs/install.rst
- hypatia/text/baseindex.py

Fixes:
- Should read `successfully` rather than `succesfully`.
- Should read `probability` rather than `proabability`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md