### PR TITLE
chore: bump ubuntu image for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
                     - "3.12"
                     - "3.13"
                 os:
-                    - "ubuntu-20.04"
+                    - "ubuntu-24.04"
                     - "macos-latest"
                 architecture:
                     - x64
@@ -35,8 +35,8 @@ jobs:
                     py: "3.10"
 
                 include:
-                    # Only run coverage on ubuntu-20.04
-                    - os: "ubuntu-20.04"
+                    # Only run coverage on ubuntu-24.04
+                    - os: "ubuntu-24.04"
                       pytest-args: "--cov"
 
 
@@ -53,7 +53,7 @@ jobs:
             - name: Running tox
               run: tox -e py -- ${{ matrix.pytest-args }}
     coverage:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
         name: Validate coverage
         steps:
             - uses: actions/checkout@v4
@@ -65,7 +65,7 @@ jobs:
             - run: pip install tox
             - run: tox -e coverage
     docs:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
         name: Build the documentation
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION
Github is warning that the `ubuntu-20.04` image will be removed on 2025-04-01.